### PR TITLE
Release 0.1.8

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "diffzip",
 	"name": "Differential ZIP Backup",
-	"version": "0.1.7",
+	"version": "0.1.8",
 	"minAppVersion": "1.8.7",
 	"description": "Back our vault up with lesser storage.",
 	"author": "vorotamoroz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "diffzip",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "diffzip",
-            "version": "0.1.7",
+            "version": "0.1.8",
             "license": "MIT",
             "dependencies": {
                 "@vrtmrz/obsidian-plugin-kit": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-plugin-kit-0.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "diffzip",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "description": "Differential ZIP Backup",
     "main": "main.js",
     "scripts": {


### PR DESCRIPTION
## Summary

- bump the plug-in, package, and lockfile versions from `0.1.7` to `0.1.8`
- release the Fancy Kit restore-confirmation adoption already merged through #13

## Validation

- clean `npm ci`; zero vulnerabilities
- `deno task test` — 59 passed
- `npm run test:ui` — 11 passed
- `npm run lint`
- `npm run prettyCheck`
- `npm run check:e2e:obsidian`
- `npm run build`
- release PR CI and tag-triggered release workflow passed
- `main.js` and `styles.css` are byte-for-byte identical to the BRAT-verified `0.1.8-fancy.1` build
- only `manifest.json` changes between the preview and final distributable, replacing the preview version with `0.1.8`

The production build retains one pre-existing Svelte warning in `SyncRemote.svelte` about capturing the initial `initialItems` value.

## Release gate

The [`0.1.8` pre-release](https://github.com/vrtmrz/diffzip/releases/tag/0.1.8) was created from this pull request head before merge so that BRAT tests the exact commit intended for `main`.

- [x] Confirm the `0.1.8` tag points to this pull request head (`4e66d5e`)
- [x] Confirm the release workflow succeeds
- [x] Confirm the release provides `main.js`, `manifest.json`, and `styles.css` as direct assets
- [x] Install `0.1.8` through BRAT and confirm the manifest reports `0.1.8`
- [x] Enable DiffZip, reload Obsidian, and confirm it starts without new errors
- [x] Confirm existing DiffZip settings are preserved
- [x] Open a restore confirmation and confirm the Markdown summary and actions remain usable
- [x] Record the Obsidian version, BRAT version, OS/device, and test date
- [x] Merge this pull request only after the BRAT installation succeeds
- [ ] After merge, promote the verified release from pre-release to stable `Latest`
