### PR TITLE
Use OW byte-view conversion and stable Fancy Kit packages

### DIFF
--- a/docs/devs.md
+++ b/docs/devs.md
@@ -62,6 +62,6 @@ Scripted responses belong to each harness or plug-in instance. Do not store resp
 
 Real Modal rendering and dismissal use the local-only Obsidian harness documented in [`test/e2e-obsidian/README.md`](../test/e2e-obsidian/README.md). The real-device scenario deliberately does not configure a scripted UI driver.
 
-## Fancy Kit previews
+## Fancy Kit dependencies
 
-Until the Fancy Kit packages are published to npm, `package.json` pins the required preview tarballs from one GitHub pre-release. Update all Fancy Kit URLs together. The plug-in kit declares an exact dependency on the matching `@vrtmrz/ui-interactions@0.1.0` preview, and the lockfile records each tarball integrity hash.
+`package.json` pins the Fancy Kit packages and `octagonal-wheels` to exact npm versions so the tested dependency set remains reproducible. Review and update the four versions together when adopting a newer contract. The plug-in kit declares an exact dependency on the matching `@vrtmrz/ui-interactions` release, and the lockfile records each package integrity hash.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
             "version": "0.1.8",
             "license": "MIT",
             "dependencies": {
-                "@vrtmrz/obsidian-plugin-kit": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-plugin-kit-0.1.0.tgz",
-                "@vrtmrz/ui-interactions": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-ui-interactions-0.1.0.tgz",
+                "@vrtmrz/obsidian-plugin-kit": "0.1.0",
+                "@vrtmrz/ui-interactions": "0.1.0",
                 "fflate": "^0.8.2",
-                "octagonal-wheels": "^0.1.38"
+                "octagonal-wheels": "0.1.48"
             },
             "devDependencies": {
                 "@aws-sdk/client-s3": "^3.726.1",
@@ -29,7 +29,7 @@
                 "@types/node": "^22.19.19",
                 "@typescript-eslint/eslint-plugin": "8.56.1",
                 "@typescript-eslint/parser": "^8.56.1",
-                "@vrtmrz/obsidian-test-session": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-test-session-0.1.0.tgz",
+                "@vrtmrz/obsidian-test-session": "0.1.0",
                 "esbuild": "0.28.1",
                 "esbuild-svelte": "^0.9.5",
                 "eslint": "^9.39.3",
@@ -3361,8 +3361,8 @@
         },
         "node_modules/@vrtmrz/obsidian-plugin-kit": {
             "version": "0.1.0",
-            "resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-plugin-kit-0.1.0.tgz",
-            "integrity": "sha512-FttoY0IEt8pbsI3cfAt+qzzg9Ruavka9v7vmBVT/hO1qSSt5ruu6aGS5y21km9qV4PcCmCZOTcDtLTD4ZS+osA==",
+            "resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-plugin-kit/-/obsidian-plugin-kit-0.1.0.tgz",
+            "integrity": "sha512-TFuqbP+HcxFhd9zvgvSkEvLa1B49omGaOmJ5V06xyECOK696UTzH7NHfTc8+/Ji6JB9QB48cAfQ9A6kKiLxGnA==",
             "license": "MIT",
             "dependencies": {
                 "@vrtmrz/ui-interactions": "0.1.0"
@@ -3373,21 +3373,22 @@
         },
         "node_modules/@vrtmrz/obsidian-test-session": {
             "version": "0.1.0",
-            "resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-test-session-0.1.0.tgz",
-            "integrity": "sha512-IUM31s7jjhj7S2X6qM7QIvgJX/XzK35878phq/wuLI849BdwfXIliUcnAdqcDN9ajGbLuMkFHy1h2Q2LB0A93A==",
+            "resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-test-session/-/obsidian-test-session-0.1.0.tgz",
+            "integrity": "sha512-asBOIRTc3xK5GF5ds5mkxN6vsO4RE8o7puvVjoJiGYSlxoFa9jzr8FwAO13CyoOriHF05pOZfTB+eQmL1aNb/A==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=20"
             },
             "peerDependencies": {
+                "@types/node": ">=20",
                 "playwright": ">=1.50.0"
             }
         },
         "node_modules/@vrtmrz/ui-interactions": {
             "version": "0.1.0",
-            "resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-ui-interactions-0.1.0.tgz",
-            "integrity": "sha512-m+15ffZrjrmM7juusfVsp3smeQo1LSPNzIUIRlpnYY4n3PQn5RmM8yR/317LIVGjC41pqhthfRqEJUCNod4c3g==",
+            "resolved": "https://registry.npmjs.org/@vrtmrz/ui-interactions/-/ui-interactions-0.1.0.tgz",
+            "integrity": "sha512-2K+DgrEdH+MaNXQOZySSfGkYTc8xMlOuaHXX/tZOC/CC8AgPF9+SjjmgpO8hZeZUZiYC2vevdGvS0yxOh1Jnjw==",
             "license": "MIT"
         },
         "node_modules/acorn": {
@@ -7428,9 +7429,9 @@
             }
         },
         "node_modules/octagonal-wheels": {
-            "version": "0.1.38",
-            "resolved": "https://registry.npmjs.org/octagonal-wheels/-/octagonal-wheels-0.1.38.tgz",
-            "integrity": "sha512-GR7b6yi9JeZm4L+NzpgKmIZq6yRL0g9/OIVtgrmmRaPTbY/6Vr15rwihkoMcbj4cWeYE4GcewgeBIWVnqXVRJQ==",
+            "version": "0.1.48",
+            "resolved": "https://registry.npmjs.org/octagonal-wheels/-/octagonal-wheels-0.1.48.tgz",
+            "integrity": "sha512-uCUEGK4UUkmumPI/fE45r877+mpANvSPe9E4O2LT95vN6Nk9PHaqQDq8NWCiYTWTlGptlhsNBstH/WxSh0ocFg==",
             "license": "MIT",
             "dependencies": {
                 "idb": "^8.0.3"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "@types/node": "^22.19.19",
         "@typescript-eslint/eslint-plugin": "8.56.1",
         "@typescript-eslint/parser": "^8.56.1",
-        "@vrtmrz/obsidian-test-session": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-test-session-0.1.0.tgz",
+        "@vrtmrz/obsidian-test-session": "0.1.0",
         "esbuild": "0.28.1",
         "esbuild-svelte": "^0.9.5",
         "eslint": "^9.39.3",
@@ -58,9 +58,9 @@
         "vitest": "^4.1.10"
     },
     "dependencies": {
-        "@vrtmrz/obsidian-plugin-kit": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-plugin-kit-0.1.0.tgz",
-        "@vrtmrz/ui-interactions": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-ui-interactions-0.1.0.tgz",
+        "@vrtmrz/obsidian-plugin-kit": "0.1.0",
+        "@vrtmrz/ui-interactions": "0.1.0",
         "fflate": "^0.8.2",
-        "octagonal-wheels": "^0.1.38"
+        "octagonal-wheels": "0.1.48"
     }
 }

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -24,6 +24,17 @@ Deno.test("toArrayBuffer: returns backing ArrayBuffer for supported binary views
     assert(toArrayBuffer(bytes.buffer) === bytes.buffer, "ArrayBuffer should be returned as-is");
 });
 
+Deno.test("toArrayBuffer: copies exactly the bytes visible through sliced views", () => {
+    const bytes = new Uint8Array([99, 1, 2, 3, 88]);
+    const sliceResult = toArrayBuffer(bytes.subarray(1, 4));
+    assertEquals([...new Uint8Array(sliceResult)], [1, 2, 3], "Uint8Array bounds should be preserved");
+    assert(sliceResult !== bytes.buffer, "a sliced Uint8Array should not expose its complete backing buffer");
+
+    const viewResult = toArrayBuffer(new DataView(bytes.buffer, 2, 2));
+    assertEquals([...new Uint8Array(viewResult)], [2, 3], "DataView bounds should be preserved");
+    assert(viewResult !== bytes.buffer, "a partial DataView should not expose its complete backing buffer");
+});
+
 Deno.test("humanReadableSize: formats edge cases and byte units", () => {
     assertEquals(humanReadableSize(Number.NaN), "0 B", "NaN should format as 0 B");
     assertEquals(humanReadableSize(-1), "0 B", "negative values should format as 0 B");

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,5 @@
 import type { XByteArray } from "./types.ts";
+export { toArrayBuffer } from "octagonal-wheels/binary";
 
 export function* pieces(source: XByteArray, chunkSize: number): Generator<Uint8Array<ArrayBuffer>, void, void> {
     let offset = 0;
@@ -12,17 +13,6 @@ export async function computeDigest(data: XByteArray) {
     const hashArray = Array.from(new Uint8Array(hashBuffer));
     const hashHex = hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
     return hashHex;
-}
-
-export function toArrayBuffer(arr: Uint8Array<ArrayBuffer> | ArrayBuffer | DataView<ArrayBuffer>): ArrayBuffer {
-    if (arr instanceof Uint8Array) {
-        return arr.buffer;
-    }
-    if (arr instanceof DataView) {
-        return arr.buffer;
-    }
-
-    return arr;
 }
 
 export function humanReadableSize(bytes: number): string {


### PR DESCRIPTION
## Summary

- replace the Fancy Kit preview tarballs with exact npm registry versions
- pin `octagonal-wheels` to `0.1.48`
- replace DiffZip's local `toArrayBuffer` implementation with `octagonal-wheels/binary`
- add consumer coverage for sliced `Uint8Array` and partial `DataView` boundaries
- update the developer documentation to describe the reproducible stable dependency set

## Why

The previous local conversion returned an entire backing buffer for partial views. That could include bytes outside the caller-visible range. The OW contract returns exactly the visible bytes and reuses the original buffer only when the view covers it completely.

Using the exact registry releases also validates the published Fancy Kit packages without relying on GitHub preview assets. There is no intended change to the visible DiffZip workflow.

## Validation

- [x] `npm ci`
- [x] `npm run lint`
- [x] `npm run test:ui` (11 tests)
- [x] `deno task test` (60 tests)
- [x] `npm run build`
- [x] `npm run check:e2e:obsidian`
- [x] real Obsidian restore-confirmation smoke on Linux
- [x] Markdown content, Cancel, and Escape dismissal verified in a real Modal

The real-Obsidian run used the local-only isolated-vault harness and Obsidian 1.12.7. The build retains an existing Svelte warning about capturing the initial value of `initialItems`; this change does not touch that component.
