### PR TITLE
Release 0.1.9

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "diffzip",
 	"name": "Differential ZIP Backup",
-	"version": "0.1.9-wakelock.1",
+	"version": "0.1.9",
 	"minAppVersion": "1.8.7",
 	"description": "Back our vault up with lesser storage.",
 	"author": "vorotamoroz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "diffzip",
-    "version": "0.1.9-wakelock.1",
+    "version": "0.1.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "diffzip",
-            "version": "0.1.9-wakelock.1",
+            "version": "0.1.9",
             "license": "MIT",
             "dependencies": {
                 "@vrtmrz/obsidian-plugin-kit": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "diffzip",
-    "version": "0.1.9-wakelock.1",
+    "version": "0.1.9",
     "description": "Differential ZIP Backup",
     "main": "main.js",
     "scripts": {


### PR DESCRIPTION
## Summary

- bump the plug-in, package, and lockfile versions from `0.1.9-wakelock.1` to `0.1.9`
- release the mobile screen wake-lock and restore-completion improvements already merged through #17
- retain the exact published `octagonal-wheels@0.1.51` dependency validated in the prerelease and on `main`

This release PR changes no runtime behaviour beyond the version reported by the manifest.

## Validation

- clean `npm ci`; zero vulnerabilities
- `deno task test` — 67 passed
- refreshed Deno coverage run — all files 88.5% branch, 68.2% function, and 76.2% line coverage; `src/wakeLock.ts` remains at 100%
- `npm run test:ui` — 11 passed
- `npm run lint`
- `npm run prettyCheck`
- `npm run check:e2e:obsidian`
- `npm run build`
- `main.js` and `styles.css` are byte-for-byte identical to the BRAT-verified `0.1.9-wakelock.1` build
- only `manifest.json` changes between the preview and final distributable, replacing the preview version with `0.1.9`
- every mobile review item on #17 passed for backup, restore, selective-sync Fetch and Send, release after completion, cancellation, and errors

The production build retains one pre-existing Svelte warning in `SyncRemote.svelte` about capturing the initial `initialItems` value.

## Release gate

Create the `0.1.9` prerelease from this pull request head so that BRAT tests the exact commit intended for `main`.

- [x] Confirm the `0.1.9` tag points to this pull request head (`4967456`)
- [x] Confirm the release workflow succeeds
- [x] Confirm the release provides `main.js`, `manifest.json`, and `styles.css` as direct assets
- [x] Install `0.1.9` through BRAT and confirm the manifest reports `0.1.9`
- [x] Enable DiffZip, reload Obsidian, and confirm it starts without new errors
- [x] Confirm existing DiffZip settings are preserved
- [x] Run a representative mobile backup and confirm the display remains awake during the operation
- [x] Confirm normal screen timeout behaviour resumes after the backup
- [x] Merge this pull request only after the BRAT installation succeeds
- [x] After merge, promote the verified release from prerelease to stable `Latest`
